### PR TITLE
rx: fix lane byte-alignment stability and skew FIFO overflow handling

### DIFF
--- a/litejesd204b/core.py
+++ b/litejesd204b/core.py
@@ -258,9 +258,11 @@ class LiteJESD204BCoreRX(Module):
         self.sync.jesd += lmfc.jref.eq(self.jref)
 
         # Links
-        self.links          = links          = []
-        self.skew_fifos     = skew_fifos     = []
-        self.skew_overflows = skew_overflows = []
+        self.links           = links           = []
+        self.skew_fifos      = skew_fifos      = []
+        self.skew_overflows  = skew_overflows  = []
+        self.lane_alignments = lane_alignments = []
+        self.lane_realigns   = lane_realigns   = []
         for n, (phy, lane) in enumerate(zip(phys, transport.sink.flatten())):
             phy_name = "jesd_phy{}".format(n if not hasattr(phy, "n") else phy.n)
             phy_cd = phy_name + "_rx"
@@ -302,6 +304,20 @@ class LiteJESD204BCoreRX(Module):
                     skew_overflow.eq(0)
                 ).Elif(skew_fifo.we & ~skew_fifo.writable,
                     skew_overflow.eq(1)
+                )
+            ]
+
+            # Lane byte alignment diagnostics: current position and a sticky flag set when an
+            # /R/ character is seen at a different position after the lane locked (a would-be
+            # byte rotation, now held off by the aligner).
+            lane_realign = Signal()
+            lane_alignments.append(link.alignment)
+            lane_realigns.append(lane_realign)
+            self.sync.jesd += [
+                If(~link.ready,
+                    lane_realign.eq(0)
+                ).Elif(link.realign,
+                    lane_realign.eq(1)
                 )
             ]
 
@@ -385,6 +401,7 @@ class LiteJESD204BCoreControl(Module, AutoCSR):
         if with_lane_status and hasattr(core, "skew_fifos"):
             self.skew_levels    = CSRStatus(32, description="Per-lane Skew FIFO levels, 8-bit per lane, lane0 in bits [7:0] (``RX only``).")
             self.skew_overflows = CSRStatus(8,  description="Per-lane sticky Skew FIFO overflow flags, cleared on link resync (``RX only``).")
+            self.lane_align     = CSRStatus(16, description="Per-lane byte alignment in bits [7:0] (2-bit per lane) and sticky realign flags in bits [11:8], cleared on link resync (``RX only``).")
 
         # # #
 
@@ -405,5 +422,9 @@ class LiteJESD204BCoreControl(Module, AutoCSR):
                     self.specials += MultiReg(level, self.skew_levels.status[8*n:8*(n + 1)])
                 for n, overflow in enumerate(core.skew_overflows[:8]):
                     self.specials += MultiReg(overflow, self.skew_overflows.status[n])
+                for n, alignment in enumerate(core.lane_alignments[:4]):
+                    self.specials += MultiReg(alignment, self.lane_align.status[2*n:2*(n + 1)])
+                for n, realign in enumerate(core.lane_realigns[:4]):
+                    self.specials += MultiReg(realign, self.lane_align.status[8 + n])
         if hasattr(core, "ilas_check"):
             self.comb += core.ilas_check.eq(~self.control.fields.ilas_check_disable)

--- a/litejesd204b/core.py
+++ b/litejesd204b/core.py
@@ -258,8 +258,9 @@ class LiteJESD204BCoreRX(Module):
         self.sync.jesd += lmfc.jref.eq(self.jref)
 
         # Links
-        self.links      = links      = []
-        self.skew_fifos = skew_fifos = []
+        self.links          = links          = []
+        self.skew_fifos     = skew_fifos     = []
+        self.skew_overflows = skew_overflows = []
         for n, (phy, lane) in enumerate(zip(phys, transport.sink.flatten())):
             phy_name = "jesd_phy{}".format(n if not hasattr(phy, "n") else phy.n)
             phy_cd = phy_name + "_rx"
@@ -280,7 +281,10 @@ class LiteJESD204BCoreRX(Module):
                 phy.rx_align.eq(link.align)
             ]
 
-            skew_fifo = SyncFIFO(32, jesd_settings.lmfc_cycles)
+            # Lanes can become ready up to ~2 multiframes apart (per-lane ILAS end + global
+            # release sampled at lmfc.zero), so a single-multiframe FIFO can silently overflow
+            # and leave that lane permanently offset; keep 4 multiframes of headroom.
+            skew_fifo = SyncFIFO(32, 4*jesd_settings.lmfc_cycles)
             skew_fifo = ClockDomainsRenamer("jesd")(skew_fifo)
             skew_fifo = ResetInserter()(skew_fifo)
             skew_fifos.append(skew_fifo)
@@ -289,6 +293,16 @@ class LiteJESD204BCoreRX(Module):
                 skew_fifo.reset.eq(~link.ready),
                 skew_fifo.we.eq(1),
                 skew_fifo.re.eq(self.ready),
+            ]
+
+            skew_overflow = Signal()
+            skew_overflows.append(skew_overflow)
+            self.sync.jesd += [
+                If(~link.ready,
+                    skew_overflow.eq(0)
+                ).Elif(skew_fifo.we & ~skew_fifo.writable,
+                    skew_overflow.eq(1)
+                )
             ]
 
             # connect data
@@ -335,7 +349,8 @@ class LiteJESD204BCoreRX(Module):
 # Core Control ----------------------------------------------------------------------------------
 
 class LiteJESD204BCoreControl(Module, AutoCSR):
-    def __init__(self, core, sys_clk_freq, default_enable=0, default_ilas_check_disable=0, default_stpl_enable=0):
+    def __init__(self, core, sys_clk_freq, default_enable=0, default_ilas_check_disable=0, default_stpl_enable=0,
+        with_lane_status = False):
         self.control = CSRStorage(fields=[
             CSRField("enable", size=1, values=[
                 ("``0b0``", "JESD core disabled."),
@@ -366,6 +381,10 @@ class LiteJESD204BCoreControl(Module, AutoCSR):
                 reset       = core.lmfc.load.reset,
                 description = "LMFC reload value on SYSREF rising edge."),
         ])
+        # Optional per-lane status CSRs (opt-in to keep the default CSR mapping unchanged).
+        if with_lane_status and hasattr(core, "skew_fifos"):
+            self.skew_levels    = CSRStatus(32, description="Per-lane Skew FIFO levels, 8-bit per lane, lane0 in bits [7:0] (``RX only``).")
+            self.skew_overflows = CSRStatus(8,  description="Per-lane sticky Skew FIFO overflow flags, cleared on link resync (``RX only``).")
 
         # # #
 
@@ -379,5 +398,12 @@ class LiteJESD204BCoreControl(Module, AutoCSR):
         ]
         if hasattr(core, "skew_fifos"):
             self.specials += MultiReg(core.skew_fifos[0].level, self.status.fields.skew_fifo)
+            if with_lane_status:
+                for n, fifo in enumerate(core.skew_fifos[:4]):
+                    level = Signal(8)
+                    self.comb    += level.eq(fifo.level)
+                    self.specials += MultiReg(level, self.skew_levels.status[8*n:8*(n + 1)])
+                for n, overflow in enumerate(core.skew_overflows[:8]):
+                    self.specials += MultiReg(overflow, self.skew_overflows.status[n])
         if hasattr(core, "ilas_check"):
             self.comb += core.ilas_check.eq(~self.control.fields.ilas_check_disable)

--- a/litejesd204b/link.py
+++ b/litejesd204b/link.py
@@ -261,9 +261,13 @@ class Aligner(Module):
         self.source  = source = Record(link_layout(data_width))
         self.latency = 1
 
+        self.hold      = Signal()  # Freeze alignment updates (set once ILAS reception starts).
+        self.alignment = Signal(2) # Current byte alignment (diagnostics).
+        self.realign   = Signal()  # Pulse: /R/ seen at a position != current alignment.
+
         # # #
 
-        alignment = Signal(2)
+        alignment = self.alignment
 
         last_data = Signal(32, reset_less=True)
         last_ctrl = Signal(4,  reset_less=True)
@@ -274,13 +278,29 @@ class Aligner(Module):
             last_ctrl.eq(sink.ctrl)
         ]
 
-        # Alignment detection
+        # Alignment detection. Updates are held once ILAS reception has started: the position is
+        # then locked by the first /R/, and a spurious decode hit during ILAS/DATA must not be
+        # allowed to permanently byte-rotate the lane.
+        detected       = Signal(2)
+        detected_valid = Signal()
         for i in range(4):
-            self.sync += [
+            self.comb += [
                 If(sink.ctrl[i] & (sink.data[8*i:8*(i+1)] == control_characters["R"]),
-                    alignment.eq(i)
+                    detected_valid.eq(1),
+                    detected.eq(i),
                 )
             ]
+        self.sync += [
+            self.realign.eq(0),
+            If(detected_valid,
+                If(~self.hold,
+                    alignment.eq(detected)
+                ),
+                If(detected != alignment,
+                    self.realign.eq(1)
+                ),
+            )
+        ]
 
         # Data selection
         data = Cat(last_data, sink.data)
@@ -637,6 +657,8 @@ class LiteJESD204BLinkRX(Module):
         self.ready      = Signal() # Output
         self.align      = Signal() # Output
         self.ilas_check = Signal(reset=int(ilas_check))
+        self.alignment  = Signal(2) # Output (diagnostics): lane byte alignment.
+        self.realign    = Signal()  # Output (diagnostics): /R/ at unexpected position.
 
         self.sink   = sink   = Record(link_layout(data_width))
         self.source = source = Record([("data", data_width)])
@@ -671,6 +693,8 @@ class LiteJESD204BLinkRX(Module):
             cgs.sink.eq(aligner.source),
             ilas.sink.eq(aligner.source),
             datapath.sink.eq(aligner.source),
+            self.alignment.eq(aligner.alignment),
+            self.realign.eq(aligner.realign),
         ]
 
         # FSM
@@ -697,6 +721,7 @@ class LiteJESD204BLinkRX(Module):
         )
         fsm.act("RECEIVE-ILAS",
             self.jsync.eq(1),
+            aligner.hold.eq(1),
             datapath.deframer.reset.eq(1),
             datapath.descrambler.reset.eq(1),
             If(ilas.done,
@@ -708,6 +733,7 @@ class LiteJESD204BLinkRX(Module):
         fsm.act("RECEIVE-DATA",
             self.jsync.eq(1),
             self.ready.eq(1),
+            aligner.hold.eq(1),
             If(cgs.valid,
                 NextState("RECEIVE-CGS")
             )


### PR DESCRIPTION
Two robustness fixes for the RX deframer, found and validated on hardware bring-up of a 4-lane link (tested at both 4.9152 and 9.8304 Gbps line rates):

## 1. Hold lane byte alignment after ILAS start

The Aligner updated the lane byte-alignment register on every /R/ detection, in every link state including RECEIVE-DATA. Any decode hit aliasing to /R/ at a different byte position (settling-time errors around ILAS, or a glitch during DATA) permanently byte-rotated the lane, varying from one link bring-up to the next.

Alignment updates are now frozen once ILAS reception starts: the first /R/ locks the position for RECEIVE-ILAS and RECEIVE-DATA. Sticky per-lane realign flags (an /R/ seen at a non-current position after lock, cleared on link resync) confirm these events do occur on real links while the hold keeps the lane stable.

## 2. Deepen lane skew FIFOs and latch overflows

Lanes can become ready up to ~2 multiframes apart (per-lane ILAS end, global release sampled at `lmfc.zero`), so the previous single-multiframe skew FIFO could silently overflow and leave that lane permanently offset within the deskewed group. This shows up in practice when individual lanes retry CGS during bring-up. The FIFOs now hold 4 multiframes, and a sticky per-lane overflow flag (cleared on link resync) lets software detect the residual misalignment and restart the link.

## CSR mapping

The new status CSRs (`skew_levels`, `skew_overflows`, `lane_align`) are **opt-in** via a new `with_lane_status` parameter on `LiteJESD204BCoreControl` (default off), so the existing CSR mapping of current users is unchanged unless requested.